### PR TITLE
feat(badge-assign): #MBA-66 assign badge type to user that already receive current type from me is no more possible

### DIFF
--- a/src/main/java/fr/cgi/minibadge/controller/UserController.java
+++ b/src/main/java/fr/cgi/minibadge/controller/UserController.java
@@ -1,5 +1,6 @@
 package fr.cgi.minibadge.controller;
 
+import fr.cgi.minibadge.core.constants.Database;
 import fr.cgi.minibadge.core.constants.Request;
 import fr.cgi.minibadge.helper.RequestHelper;
 import fr.cgi.minibadge.security.AssignRight;
@@ -25,14 +26,15 @@ public class UserController extends ControllerHelper {
         this.userService = serviceFactory.userService();
     }
 
-    @Get("/users-search")
+    @Get("type/:typeId/users-search")
     @ApiDoc("Get users from query")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(AssignRight.class)
     public void searchUsers(HttpServerRequest request) {
         String query = request.params().get(Request.QUERY);
+        long typeId = Long.parseLong(request.params().get(Database.TYPEID));
 
-        UserUtils.getUserInfos(eb, request, user -> userService.search(request, user, query)
+        UserUtils.getUserInfos(eb, request, user -> userService.search(request, user, typeId, query)
                 .onSuccess(users -> renderJson(request, RequestHelper.addAllValue(new JsonObject(), users)))
                 .onFailure(err -> renderError(request, new JsonObject().put(Request.MESSAGE, err.getMessage()))));
     }

--- a/src/main/java/fr/cgi/minibadge/service/UserService.java
+++ b/src/main/java/fr/cgi/minibadge/service/UserService.java
@@ -14,10 +14,11 @@ public interface UserService {
      *
      * @param request request from which we need to retrieve users
      * @param user    current user that query search
+     * @param typeId  badge type identifier on which we currently search users.
      * @param query   to filter on user firstName/lastName
      * @return return future containing list of users
      */
-    Future<List<User>> search(HttpServerRequest request, UserInfos user, String query);
+    Future<List<User>> search(HttpServerRequest request, UserInfos user, Long typeId, String query);
 
     /**
      * get users from ids
@@ -43,4 +44,14 @@ public interface UserService {
      * @return
      */
     Future<JsonArray> anonimyzeUser(String userId, String host, String language);
+
+    /**
+     * Count users that gave me this (:typeId) badge typed
+     *
+     * @param typeId type identifier
+     * @param assigner assigner that assigned this id typed badge
+     * @param  receiverIds that potentially received this typed badge by current assigner
+     * @return return future containing list of users that received the typed badge from current assigner
+     */
+    Future<List<User>> getAlreadyTypedAssignedFromUser(long typeId, UserInfos assigner, List<String> receiverIds);
 }

--- a/src/main/resources/public/ts/services/user.service.ts
+++ b/src/main/resources/public/ts/services/user.service.ts
@@ -3,17 +3,18 @@ import http, {AxiosResponse} from 'axios';
 import {IUserPayload, IUsersResponses, User} from "../models/user.model";
 
 export interface IUserService {
-    searchUsers(payload: IUserPayload): Promise<User[]>;
+    searchUsers(typeId: number, payload: IUserPayload): Promise<User[]>;
 }
 
 export const userService: IUserService = {
     /**
      * search users from query
      *
+     * @param typeId type identifier from which we search users
      * @param payload params to send to the backend
      */
-    searchUsers: async (payload: IUserPayload): Promise<User[]> =>
-        http.get(`/minibadge/users-search${payload.query ? `?query=${payload.query}` : ''}`)
+    searchUsers: async (typeId: number, payload: IUserPayload): Promise<User[]> =>
+        http.get(`/minibadge/type/${typeId}/users-search${payload.query ? `?query=${payload.query}` : ''}`)
             .then((res: AxiosResponse) => {
                 let usersResponses: IUsersResponses = res.data;
                 return new User().toList(usersResponses ? usersResponses.all : []);

--- a/src/main/resources/public/ts/sniplets/badge-assign.sniplet.ts
+++ b/src/main/resources/public/ts/sniplets/badge-assign.sniplet.ts
@@ -1,4 +1,4 @@
-import {Behaviours, idiom as lang, model, notify} from "entcore"
+import {Behaviours, idiom as lang, notify} from "entcore"
 import {
     badgeAssignedService,
     badgeTypeService,
@@ -116,7 +116,7 @@ class ViewModel implements IViewModel {
     onSearchUser = async (): Promise<void> => {
         this.userPayload.query = this.searchQuery;
         if (this.searchQuery && this.searchQuery.trim() != '')
-            this.userService.searchUsers(this.userPayload)
+            this.userService.searchUsers(this.badgeType.id, this.userPayload)
                 .then((data: User[]) => {
                     if (data) this.userSearchResults = data
                         .filter((user: User) => !this.isUserSelected(user));


### PR DESCRIPTION
## Describe your changes
Si j'ai déjà assigné un badge d'un certain type à un utilisateur, celui-ci ne remonte plus dans la recherche du type de badge en question.

## Checklist tests
- Aller sur la modal d'assignation d'un badge
- rechercher un utilisateur et lui assigner se badge
- retourner sur la modal d'assignation du même badge
- rechercher le même utilisateur, il n'apparait plus
- révoquer le badge (sur la page dédié)
- a la recherche, l'utilisateur réapparait. 

[Doc - Api Users](https://confluence.support-ent.fr/display/BAD/Users)

## Issue ticket number and link
[Jira - MBA-66](https://jira.support-ent.fr/browse/MBA-66)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
