### PR TITLE
feat(chart): #MBA-71 assign badge to user is now possible even if he doesn't accept chart

### DIFF
--- a/src/main/java/fr/cgi/minibadge/security/UsersAssignRight.java
+++ b/src/main/java/fr/cgi/minibadge/security/UsersAssignRight.java
@@ -71,14 +71,14 @@ public class UsersAssignRight implements ResourcesProvider {
                         return this.getUsers(request, ownerIds);
                     })
                     .onSuccess(usersArray -> {
-                        List<User> users = new User().toList(usersArray);
+                        List<User> receivers = new User().toList(usersArray);
                         boolean isAuthorizedToAssign = SettingHelper
-                                .isAuthorizedToAssign(new User(userInfos), users, typeSetting);
-                        boolean canUsersReceive = users.stream()
+                                .isAuthorizedToAssign(new User(userInfos), receivers, typeSetting);
+                        boolean canUsersReceive = receivers.stream()
                                 .allMatch(user ->
-                                        user.permissions().acceptChart() != null
-                                                && user.permissions().acceptReceive() != null);
-                        handler.handle(ownerIds.size() == users.size() && isAuthorizedToAssign && canUsersReceive);
+                                        user.permissions().acceptChart() == null
+                                                || user.permissions().acceptReceive() != null);
+                        handler.handle(ownerIds.size() == receivers.size() && isAuthorizedToAssign && canUsersReceive);
                     })
                     .onFailure(err -> handler.handle(false));
         });

--- a/src/main/java/fr/cgi/minibadge/service/impl/DefaultUserService.java
+++ b/src/main/java/fr/cgi/minibadge/service/impl/DefaultUserService.java
@@ -81,8 +81,8 @@ public class DefaultUserService implements UserService {
     private List<User> mapToAuthorizedAssignUsers(UserInfos user, JsonArray users) {
         return new User().toList(users)
                 .stream().filter(queriedUser ->
-                        queriedUser.permissions().acceptChart() != null
-                                && queriedUser.permissions().acceptReceive() != null
+                        queriedUser.permissions().acceptChart() == null
+                                || queriedUser.permissions().acceptReceive() != null
                                 // We currently consider that all types have default setting
                                 && SettingHelper.isAuthorizedToAssign(new User(user), queriedUser,
                                 SettingHelper.getDefaultTypeSetting())


### PR DESCRIPTION
## Describe your changes
Désormais, Il est possible d'assigner un badge à un élève même s'il n'a pas accepté la charte, tant qu'il possède le droit de recevoir.

## Checklist tests
- Décerner un badge sur un utilisateur n'ayant pas accepté minibadge.
- c'est possible !
- se connecter avec ce même utilisateur
- observer (sans accepter la charte) qu'il a bien reçu le badge en question.

## Issue ticket number and link
[Jira - MBA-71](https://jira.support-ent.fr/browse/MBA-71)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
